### PR TITLE
Add new roles Committee & Service

### DIFF
--- a/app/models/decidim/participatory_process_user_role.rb
+++ b/app/models/decidim/participatory_process_user_role.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Defines a relation between a user and a participatory process, and what
+  # kind of relation does the user has.
+  class ParticipatoryProcessUserRole < ApplicationRecord
+    include Traceable
+    include Loggable
+
+    belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User", optional: true
+    belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: "Decidim::ParticipatoryProcess", optional: true
+
+    alias participatory_space participatory_process
+
+    ROLES = Decidim.participatory_process_user_roles.uniq
+    validates :role, inclusion: { in: ROLES }, uniqueness: { scope: [:user, :participatory_process] }
+    validate :user_and_participatory_process_same_organization
+
+    def self.log_presenter_class_for(_log)
+      Decidim::ParticipatoryProcesses::AdminLog::ParticipatoryProcessUserRolePresenter
+    end
+
+    private
+
+    # Private: check if the process and the user have the same organization
+    def user_and_participatory_process_same_organization
+      return if !participatory_process || !user
+      errors.add(:participatory_process, :invalid) unless user.organization == participatory_process.organization
+    end
+  end
+end

--- a/app/permissions/decidim/participatory_processes/questions_permissions.rb
+++ b/app/permissions/decidim/participatory_processes/questions_permissions.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    class QuestionsPermissions < Decidim::ParticipatoryProcesses::Permissions
+      def permissions
+
+        Rails.logger.debug "==========="
+        Rails.logger.debug "Decidim::ParticipatoryProcesses::QuestionsPermissions"
+        Rails.logger.debug permission_action.inspect
+        Rails.logger.debug "==========="
+
+        committee_action?
+        service_action?
+
+        org_admin_action?
+
+        Rails.logger.debug permission_action.inspect
+        Rails.logger.debug "==========="
+
+        permission_action
+      end
+
+      def committee_action?
+        return unless can_manage_process?(role: :committee)
+        questions_action?
+      end
+
+      def service_action?
+        return unless can_manage_process?(role: :service)
+        questions_action?
+      end
+
+      private
+
+      def questions_action?
+        return if permission_action.subject == :process &&
+                    [:create,:update].include?(permission_action.action)
+
+        is_allowed = [
+          :component,
+          :component_data,
+          :questions,
+          :question,
+          :participatory_space,
+          :process
+        ].include?(permission_action.subject)
+        allow! if is_allowed
+      end
+
+    end
+  end
+end

--- a/app/permissions/decidim/questions/admin/permissions.rb
+++ b/app/permissions/decidim/questions/admin/permissions.rb
@@ -3,10 +3,18 @@
 module Decidim
   module Questions
     module Admin
-      class Permissions < Decidim::DefaultPermissions
+      class Permissions < Decidim::ParticipatoryProcesses::Permissions
         def permissions
+
+          Rails.logger.debug "==========="
+          Rails.logger.debug "Decidim::Questions::Admin::Permissions"
+          Rails.logger.debug permission_action.inspect
+          Rails.logger.debug "==========="
+
           # The public part needs to be implemented yet
           return permission_action if permission_action.scope != :admin
+
+          has_access? if permission_action.subject == :component && permission_action.action == :read
 
           if create_permission_action?
             # There's no special condition to create question notes, only
@@ -45,6 +53,9 @@ module Decidim
             allow! if permission_action.action == :publish
           end
 
+          Rails.logger.debug permission_action.inspect
+          Rails.logger.debug "==========="
+
           permission_action
         end
 
@@ -52,6 +63,12 @@ module Decidim
 
         def question
           @question ||= context.fetch(:question, nil)
+        end
+
+        def has_access?
+          toggle_allow(admin_user? ||
+            can_manage_process?(role: :committee) ||
+            can_manage_process?(role: :service))
         end
 
         def admin_creation_is_enabled?

--- a/app/queries/decidim/participatory_processes/admin/committee_users.rb
+++ b/app/queries/decidim/participatory_processes/admin/committee_users.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      # A class used to find the users that can operate as committee members
+      class CommitteeUsers < Rectify::Query
+        # Syntactic sugar to initialize the class and return the queried objects.
+        #
+        # process - a process that needs to find its moderators
+        def self.for(process)
+          new(process).query
+        end
+
+        # Initializes the class.
+        #
+        # process - a process that needs to find its process admins
+        def initialize(process)
+          @process = process
+        end
+
+        # Finds the users with role committee for the given
+        # process.
+        #
+        # Returns an ActiveRecord::Relation.
+        def query
+          Decidim::User.where(id: organization_admins + process_users)
+        end
+
+        private
+
+        attr_reader :process
+
+        def organization_admins
+          process.organization.admins
+        end
+
+        def process_users
+          Decidim::ParticipatoryProcessUserRole
+            .where(participatory_process: process)
+            .where(role: [:admin,:committee])
+            .pluck(:decidim_user_id)
+            .uniq
+        end
+      end
+    end
+  end
+end

--- a/app/queries/decidim/participatory_processes/admin/moderators_only.rb
+++ b/app/queries/decidim/participatory_processes/admin/moderators_only.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      # A class used to find the users that can moderate the participatory
+      # process.
+      # ( more restrictive
+      #   than Decidim::ParticipatoryProcesses::Admin::Moderators )
+      class ModeratorsOnly < Rectify::Query
+        # Syntactic sugar to initialize the class and return the queried objects.
+        #
+        # process - a process that needs to find its moderators
+        def self.for(process)
+          new(process).query
+        end
+
+        # Initializes the class.
+        #
+        # process - a process that needs to find its process admins
+        def initialize(process)
+          @process = process
+        end
+
+        # Finds organization admins and the users with role moderator
+        # for the given process.
+        #
+        # Returns an ActiveRecord::Relation.
+        def query
+          Decidim::User.where(id: organization_admins + process_users)
+        end
+
+        private
+
+        attr_reader :process
+
+        def organization_admins
+          process.organization.admins
+        end
+
+        def process_users
+          Decidim::ParticipatoryProcessUserRole
+            .where(participatory_process: process)
+            .where(role: [:admin,:moderator])
+            .pluck(:decidim_user_id)
+            .uniq
+        end
+      end
+    end
+  end
+end

--- a/app/queries/decidim/participatory_processes/admin/service_users.rb
+++ b/app/queries/decidim/participatory_processes/admin/service_users.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      # A class used to find the users that can operate as service members
+      class ServiceUsers < Rectify::Query
+        # Syntactic sugar to initialize the class and return the queried objects.
+        #
+        # process - a process that needs to find its moderators
+        def self.for(process)
+          new(process).query
+        end
+
+        # Initializes the class.
+        #
+        # process - a process that needs to find its process admins
+        def initialize(process)
+          @process = process
+        end
+
+        # Finds the users with role service for the given
+        # process.
+        #
+        # Returns an ActiveRecord::Relation.
+        def query
+          Decidim::User.where(id: organization_admins + process_users)
+        end
+
+        private
+
+        attr_reader :process
+
+        def organization_admins
+          process.organization.admins
+        end
+
+        def process_users
+          Decidim::ParticipatoryProcessUserRole
+            .where(participatory_process: process)
+            .where(role: [:admin,:service])
+            .pluck(:decidim_user_id)
+            .uniq
+        end
+      end
+    end
+  end
+end

--- a/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
+++ b/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
@@ -1,0 +1,76 @@
+<div class="card" id="processes">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t "decidim.admin.titles.participatory_processes" %><%= link_to t("actions.new_process", scope: "decidim.admin"), ["new", "participatory_process"], class: "button tiny button--title" if allowed_to? :create, :process %>
+    </h2>
+  </div>
+  <div class="card-section">
+    <div class="table-scroll">
+      <table class="table-list">
+        <thead>
+          <tr>
+            <th><%= t("models.participatory_process.fields.title", scope: "decidim.admin") %></th>
+            <th><%= t("models.participatory_process.fields.created_at", scope: "decidim.admin") %></th>
+            <th><%= t("models.participatory_process.fields.private", scope: "decidim.admin") %></th>
+            <th class="table-list__actions"><%= t("models.participatory_process.fields.published", scope: "decidim.admin") %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @participatory_processes.each do |process| %>
+            <tr>
+              <td>
+                <% if process.promoted? %>
+                  <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="<%= t("models.participatory_process.fields.promoted", scope: "decidim.admin") %>">
+                    <%= icon "star" %>
+                  </span>
+                <% end %>
+                <% if allowed_to? :update, :process, process: process %>
+                  <%= link_to translated_attribute(process.title), edit_participatory_process_path(process) %><br />
+                <% elsif (process.has_questions_component?) && (allowed_to? :manage, :questions, process: process) %>
+                  <%= link_to translated_attribute(process.title), manage_component_path(process.questions_component) %><br />
+                <% elsif allowed_to? :preview, :process, process: process %>
+                  <%= link_to translated_attribute(process.title), decidim_participatory_processes.participatory_process_path(process) %><br />
+                <% elsif allowed_to? :read, :moderation, process: process %>
+                  <%= link_to translated_attribute(process.title), moderations_path(process) %><br />
+                <% else %>
+                  <%= translated_attribute(process.title) %>
+                <% end %>
+              </td>
+              <td>
+                <%= l process.created_at, format: :short %>
+              </td>
+              <td class="table-list__state">
+                <% if process.private_space? %>
+                  <strong class="text-alert"><%= t("participatory_processes.index.private", scope: "decidim.admin") %></strong>
+                <% else %>
+                  <strong class="text-success"><%= t("participatory_processes.index.public", scope: "decidim.admin") %></strong>
+                <% end %>
+              </td>
+              <td class="table-list__state">
+                <% if process.published? %>
+                  <strong class="text-success"><%= t("participatory_processes.index.published", scope: "decidim.admin") %></strong>
+                <% else %>
+                  <strong class="text-alert"><%= t("participatory_processes.index.not_published", scope: "decidim.admin") %></strong>
+                <% end %>
+              </td>
+              <td class="table-list__actions">
+                <% if allowed_to? :create, :process, process: process %>
+                  <%= icon_link_to "clipboard", new_participatory_process_copy_path(process), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
+                <% end %>
+
+                <% if allowed_to? :update, :process, process: process %>
+                  <%= icon_link_to "pencil", edit_participatory_process_path(process), t("actions.configure", scope: "decidim.admin"), class: "action-icon--new" %>
+                <% end %>
+
+                <% if allowed_to? :preview, :process, process: process %>
+                  <%= icon_link_to "eye", decidim_participatory_processes.participatory_process_path(process), t("actions.preview", scope: "decidim.admin"), class: "action-icon--preview" %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/decidim/admin/participatory_process.html.erb
+++ b/app/views/layouts/decidim/admin/participatory_process.html.erb
@@ -1,0 +1,89 @@
+<% content_for :secondary_nav do %>
+  <div class="secondary-nav secondary-nav--subnav">
+    <ul>
+      <%= public_page_link decidim_participatory_processes.participatory_process_path(current_participatory_space) %>
+      <% if allowed_to? :update, :process, process: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_participatory_processes.edit_participatory_process_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_participatory_processes.edit_participatory_process_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :process_step %>
+        <li <% if is_active_link?(decidim_admin_participatory_processes.participatory_process_steps_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("steps", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_participatory_processes.participatory_process_steps_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :component %>
+        <li <% if is_active_link?(decidim_admin_participatory_processes.components_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <% if allowed_to? :update, :process, process: current_participatory_space %>
+            <%= aria_selected_link_to t("components", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_participatory_processes.components_path(current_participatory_space) %>
+          <% end %>
+          <ul>
+            <% current_participatory_space.components.each do |component| %>
+              <% if component.manifest.admin_engine %>
+                <% if allowed_to? :read, component.manifest.name %>
+                  <li <% if is_active_link?(manage_component_path(component)) || is_active_link?(decidim_admin_participatory_processes.edit_component_path(current_participatory_space, component)) || is_active_link?(decidim_admin_participatory_processes.edit_component_permissions_path(current_participatory_space, component)) %> class="is-active" <% end %>>
+                    <%= link_to manage_component_path(component) do %>
+                      <%= translated_attribute component.name %>
+                      <% if component.primary_stat.present? %>
+                        <span class="component-counter <%= "component-counter--off" if component.primary_stat.zero? %>"><%= component.primary_stat %></span>
+                      <% end %>
+                    <% end %>
+                  </li>
+                <% end %>
+              <% end %>
+            <% end %>
+          </ul>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :category %>
+        <li <% if is_active_link?(decidim_admin_participatory_processes.categories_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_participatory_processes.categories_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to?(:read, :attachment_collection) || allowed_to?(:read, :attachment) %>
+        <li>
+          <span class="secondary-nav__subtitle"><%= t("attachments", scope: "decidim.admin.menu.participatory_processes_submenu") %></span>
+          <ul>
+            <% if allowed_to? :read, :attachment_collection %>
+              <li <% if is_active_link?(decidim_admin_participatory_processes.participatory_process_attachment_collections_path(current_participatory_space)) %> class="is-active" <% end %>>
+                <%= aria_selected_link_to t("attachment_collections", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_participatory_processes.participatory_process_attachment_collections_path(current_participatory_space) %>
+              </li>
+            <% end %>
+            <% if allowed_to? :read, :attachment %>
+              <li <% if is_active_link?(decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space)) %> class="is-active" <% end %>>
+                <%= aria_selected_link_to t("attachment_files", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space) %>
+              </li>
+            <% end %>
+          </ul>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :process_user_role %>
+        <li <% if is_active_link?(decidim_admin_participatory_processes.participatory_process_user_roles_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("process_admins", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_participatory_processes.participatory_process_user_roles_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :space_private_user %>
+        <li <% if is_active_link?(decidim_admin_participatory_processes.participatory_space_private_users_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("private_users", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_participatory_processes.participatory_space_private_users_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :moderation %>
+        <li <% if is_active_link?(decidim_admin_participatory_processes.moderations_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("moderations", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_participatory_processes.moderations_path(current_participatory_space) %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= render "layouts/decidim/admin/application" do %>
+  <div class="process-title">
+    <div class="process-title-content">
+      <%= link_to translated_attribute(current_participatory_space.title), decidim_participatory_processes.participatory_process_path(current_participatory_space), target: "_blank" %>
+    </div>
+  </div>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
+<% end %>

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -1,3 +1,4 @@
+require 'extends/decidim-core/core_extend.rb'
 require 'extends/decidim-core/commands/decidim/amendable/create_extend.rb'
 require 'extends/decidim-core/commands/decidim/amendable/promote_extend.rb'
 require 'extends/decidim-core/helpers/decidim/cells_helper_extend.rb'

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -1,5 +1,8 @@
 require 'extends/decidim-core/core_extend.rb'
+require 'extends/decidim-core/helpers/decidim/application_helper_extend.rb'
+require 'extends/decidim-admin/helpers/decidim/admin/application_helper_extend.rb'
 require 'extends/decidim-participatory_processes/models/decidim/participatory_process_extend.rb'
+require 'extends/decidim-participatory_processes/controllers/decidim/participatory_processes/admin/participatory_processes_controller_extend.rb'
 require 'extends/decidim-core/commands/decidim/amendable/create_extend.rb'
 require 'extends/decidim-core/commands/decidim/amendable/promote_extend.rb'
 require 'extends/decidim-core/helpers/decidim/cells_helper_extend.rb'

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -1,4 +1,5 @@
 require 'extends/decidim-core/core_extend.rb'
+require 'extends/decidim-participatory_processes/models/decidim/participatory_process_extend.rb'
 require 'extends/decidim-core/commands/decidim/amendable/create_extend.rb'
 require 'extends/decidim-core/commands/decidim/amendable/promote_extend.rb'
 require 'extends/decidim-core/helpers/decidim/cells_helper_extend.rb'

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -1,7 +1,26 @@
 require 'extends/decidim-core/core_extend.rb'
 require 'extends/decidim-core/helpers/decidim/application_helper_extend.rb'
 require 'extends/decidim-admin/helpers/decidim/admin/application_helper_extend.rb'
-require 'extends/decidim-participatory_processes/models/decidim/participatory_process_extend.rb'
+
+ActiveSupport.on_load(:active_record) {
+
+  def database_exists?
+    ActiveRecord::Base.connection
+  rescue ActiveRecord::NoDatabaseError
+    false
+  else
+    true
+  end
+
+  # Models needs to be loaded AFTER DB init because of legacy Migrations
+  if database_exists?
+    if ActiveRecord::Base.connection.table_exists?(:decidim_participatory_processes)
+      require 'extends/decidim-participatory_processes/models/decidim/participatory_process_extend.rb'
+    end
+  end
+  
+}
+
 require 'extends/decidim-participatory_processes/controllers/decidim/participatory_processes/admin/participatory_processes_controller_extend.rb'
 require 'extends/decidim-core/commands/decidim/amendable/create_extend.rb'
 require 'extends/decidim-core/commands/decidim/amendable/promote_extend.rb'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,12 @@ en:
         one: Vote
         other: Votes
   decidim:
+    admin:
+      models:
+        participatory_process_user_role:
+          roles:
+            committee: Committee
+            service: Service
     components:
       questions:
         actions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
             official_questions_enabled: Official questions enabled
             participatory_texts_enabled: Participatory texts enabled
             question_answering_enabled: Question answering enabled
+            question_answering_roles_enabled: Question answering roles enabled
             question_edit_before_minutes: Questions can be edited by authors before this many minutes passes
             question_length: Maximum question body length
             question_limit: Question limit per user

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -61,6 +61,12 @@ fr:
         one: Vote
         other: Votes
   decidim:
+    admin:
+      models:
+        participatory_process_user_role:
+          roles:
+            committee: Comité de pilotage
+            service: Service
     components:
       questions:
         actions:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -89,6 +89,7 @@ fr:
             official_questions_enabled: Autoriser la création de propositions officielles
             participatory_texts_enabled: Textes participatifs activés
             question_answering_enabled: Autoriser la réponse officielle aux propositions
+            question_answering_roles_enabled: Activer les rôles de \"Comité de pilotage\" et de \"Service\" de reponses officielles
             question_edit_before_minutes: Délai (en minutes) après lequel les auteurs ne peuvent plus modifier leurs propositions
             question_length: Nombre maximum de caractères du corps de la proposition
             question_limit: Limite de proposition par utilisateur

--- a/lib/decidim/questions/component.rb
+++ b/lib/decidim/questions/component.rb
@@ -28,6 +28,7 @@ Decidim.register_component(:questions) do |component|
     settings.attribute :threshold_per_question, type: :integer, default: 0
     settings.attribute :can_accumulate_supports_beyond_threshold, type: :boolean, default: false
     settings.attribute :question_answering_enabled, type: :boolean, default: true
+    settings.attribute :question_answering_roles_enabled, type: :boolean, default: true
     settings.attribute :official_questions_enabled, type: :boolean, default: true
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :geocoding_enabled, type: :boolean, default: false
@@ -136,7 +137,9 @@ Decidim.register_component(:questions) do |component|
       participatory_space: participatory_space,
       settings: {
         vote_limit: 0,
-        collaborative_drafts_enabled: true
+        collaborative_drafts_enabled: true,
+        question_answering_enabled: true,
+        question_answering_roles_enabled: true
       },
       step_settings: step_settings
     }

--- a/lib/decidim/questions/test/factories.rb
+++ b/lib/decidim/questions/test/factories.rb
@@ -399,4 +399,34 @@ FactoryBot.define do
     description { Faker::Lorem.sentences(3).join("\n") }
     component { create(:question_component) }
   end
+
+  factory :process_committee, parent: :user, class: "Decidim::User" do
+    transient do
+      participatory_process { create(:participatory_process) }
+    end
+
+    organization { participatory_process.organization }
+
+    after(:create) do |user, evaluator|
+      create :participatory_process_user_role,
+             user: user,
+             participatory_process: evaluator.participatory_process,
+             role: :committee
+    end
+  end
+
+  factory :process_service, parent: :user, class: "Decidim::User" do
+    transient do
+      participatory_process { create(:participatory_process) }
+    end
+
+    organization { participatory_process.organization }
+
+    after(:create) do |user, evaluator|
+      create :participatory_process_user_role,
+             user: user,
+             participatory_process: evaluator.participatory_process,
+             role: :service
+    end
+  end
 end

--- a/lib/extends/decidim-admin/helpers/decidim/admin/application_helper_extend.rb
+++ b/lib/extends/decidim-admin/helpers/decidim/admin/application_helper_extend.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Decidim::Admin::ApplicationHelper.module_eval do
+  include Decidim::IconHelper
+end

--- a/lib/extends/decidim-core/core_extend.rb
+++ b/lib/extends/decidim-core/core_extend.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Decidim.module_eval do
+
+  config_accessor :participatory_process_user_roles do
+    %w(admin collaborator moderator committee service)
+  end
+
+end

--- a/lib/extends/decidim-core/helpers/decidim/application_helper_extend.rb
+++ b/lib/extends/decidim-core/helpers/decidim/application_helper_extend.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Decidim::ApplicationHelper.module_eval do
+  include Decidim::IconHelper
+end

--- a/lib/extends/decidim-participatory_processes/controllers/decidim/participatory_processes/admin/participatory_processes_controller_extend.rb
+++ b/lib/extends/decidim-participatory_processes/controllers/decidim/participatory_processes/admin/participatory_processes_controller_extend.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Questions
+    module ParticipatoryProcesses
+      module Admin
+        module ParticipatoryProcessesControllerExtend
+
+          def permission_class_chain
+            [
+              Decidim::ParticipatoryProcesses::QuestionsPermissions,
+              Decidim::ParticipatoryProcesses::Permissions,
+              Decidim::Admin::Permissions
+            ]
+          end
+          
+        end # end module ParticipatoryProcessesControllerExtends
+      end # end module Admin
+    end # end module ParticipatoryProcesses
+  end # end module Questions
+end # end module Decidim
+
+Decidim::ParticipatoryProcesses::Admin::ParticipatoryProcessesController.class_eval do
+  prepend(Decidim::Questions::ParticipatoryProcesses::Admin::ParticipatoryProcessesControllerExtend)
+end

--- a/lib/extends/decidim-participatory_processes/models/decidim/participatory_process_extend.rb
+++ b/lib/extends/decidim-participatory_processes/models/decidim/participatory_process_extend.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Questions
+    module ParticipatoryProcessExtend
+      def has_questions_component?
+        components.where(manifest_name: "questions").any?
+      end
+
+      def questions_component
+        i = components.index { |i| i["manifest_name"] == "questions" }
+        components[i]
+      end
+
+      def moderators_only
+        "#{admin_module_name}::ModeratorsOnly".constantize.for(self)
+      end
+
+      def service_users
+        "#{admin_module_name}::ServiceUsers".constantize.for(self)
+      end
+
+      def committee_users
+        "#{admin_module_name}::CommitteeUsers".constantize.for(self)
+      end
+
+    end # end module ParticipatoryProcessExtends
+  end # end module Questions
+end # end module Decidim
+
+Decidim::ParticipatoryProcess.class_eval do
+  prepend(Decidim::Questions::ParticipatoryProcessExtend)
+end

--- a/lib/tasks/decidim_tasks.rake
+++ b/lib/tasks/decidim_tasks.rake
@@ -7,26 +7,26 @@ namespace :decidim do
   desc "Setup environment so that only decidim migrations are installed."
   task :choose_target_plugins do
     ENV["FROM"] = %w(
-      decidim_participatory_processes
       decidim
-      decidim_system
-      decidim_assemblies
-      decidim_conferences
-      decidim_consultations
-      decidim_admin
       decidim_accountability
+      decidim_admin
+      decidim_assemblies
       decidim_blogs
       decidim_budgets
       decidim_comments
+      decidim_conferences
+      decidim_consultations
       decidim_debates
       decidim_forms
       decidim_initiatives
       decidim_meetings
       decidim_pages
+      decidim_participatory_processes
       decidim_proposals
       decidim_questions
       decidim_sortitions
       decidim_surveys
+      decidim_system
       decidim_verifications
     ).join(",")
   end

--- a/lib/tasks/decidim_tasks.rake
+++ b/lib/tasks/decidim_tasks.rake
@@ -8,25 +8,25 @@ namespace :decidim do
   task :choose_target_plugins do
     ENV["FROM"] = %w(
       decidim
-      decidim_accountability
-      decidim_admin
+      decidim_participatory_processes
+      decidim_system
       decidim_assemblies
+      decidim_conferences
+      decidim_consultations
+      decidim_admin
+      decidim_accountability
       decidim_blogs
       decidim_budgets
       decidim_comments
-      decidim_conferences
-      decidim_consultations
       decidim_debates
       decidim_forms
       decidim_initiatives
       decidim_meetings
       decidim_pages
-      decidim_participatory_processes
       decidim_proposals
       decidim_questions
       decidim_sortitions
       decidim_surveys
-      decidim_system
       decidim_verifications
     ).join(",")
   end

--- a/lib/tasks/decidim_tasks.rake
+++ b/lib/tasks/decidim_tasks.rake
@@ -7,8 +7,8 @@ namespace :decidim do
   desc "Setup environment so that only decidim migrations are installed."
   task :choose_target_plugins do
     ENV["FROM"] = %w(
-      decidim
       decidim_participatory_processes
+      decidim
       decidim_system
       decidim_assemblies
       decidim_conferences

--- a/spec/queries/admin/committee_users_spec.rb
+++ b/spec/queries/admin/committee_users_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ParticipatoryProcesses
+  describe Admin::CommitteeUsers do
+    subject { described_class.new(participatory_process) }
+
+    let(:organization) { create :organization }
+    let(:participatory_process) { create :participatory_process, organization: organization }
+    let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:participatory_process_admin) do
+      create(:process_admin, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_moderator) do
+      create(:process_moderator, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_collaborator) do
+      create(:process_collaborator, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_service) do
+      create(:process_service, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_committee) do
+      create(:process_committee, participatory_process: participatory_process)
+    end
+
+    it "returns the organization admins and participatory process admins" do
+      expect(subject.query).to match_array([admin, participatory_process_admin, participatory_process_committee])
+    end
+  end
+end

--- a/spec/queries/admin/moderators_only_spec.rb
+++ b/spec/queries/admin/moderators_only_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ParticipatoryProcesses
+  describe Admin::ModeratorsOnly do
+    subject { described_class.new(participatory_process) }
+
+    let(:organization) { create :organization }
+    let(:participatory_process) { create :participatory_process, organization: organization }
+    let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:participatory_process_admin) do
+      create(:process_admin, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_moderator) do
+      create(:process_moderator, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_collaborator) do
+      create(:process_collaborator, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_service) do
+      create(:process_service, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_committee) do
+      create(:process_committee, participatory_process: participatory_process)
+    end
+
+    it "returns the organization admins and participatory process admins" do
+      expect(subject.query).to match_array([admin, participatory_process_admin, participatory_process_moderator])
+    end
+  end
+end

--- a/spec/queries/admin/service_users_spec.rb
+++ b/spec/queries/admin/service_users_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ParticipatoryProcesses
+  describe Admin::ServiceUsers do
+    subject { described_class.new(participatory_process) }
+
+    let(:organization) { create :organization }
+    let(:participatory_process) { create :participatory_process, organization: organization }
+    let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:participatory_process_admin) do
+      create(:process_admin, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_moderator) do
+      create(:process_moderator, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_collaborator) do
+      create(:process_collaborator, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_service) do
+      create(:process_service, participatory_process: participatory_process)
+    end
+    let!(:participatory_process_committee) do
+      create(:process_committee, participatory_process: participatory_process)
+    end
+
+    it "returns the organization admins and participatory process admins" do
+      expect(subject.query).to match_array([admin, participatory_process_admin, participatory_process_service])
+    end
+  end
+end

--- a/spec/shared/invite_process_users_shared_context.rb
+++ b/spec/shared/invite_process_users_shared_context.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+shared_context "when inviting process users" do
+  let(:participatory_process) { create :participatory_process }
+  let(:organization) { participatory_process.organization }
+  let(:user) { create :user, :admin, :confirmed, organization: participatory_process.organization }
+  let(:email) { "this_email_does_not_exist@example.org" }
+  let(:role) { "Moderator" }
+
+  def invite_user
+    login_as user, scope: :user
+
+    visit decidim_admin_participatory_processes.participatory_process_user_roles_path(participatory_process)
+    within ".container" do
+      click_link "New process user"
+    end
+
+    fill_in "Name", with: "Alice Liddel"
+    fill_in "Email", with: email
+    select role, from: "Role"
+    click_button "Create"
+    logout :user
+  end
+end

--- a/spec/system/admin/invite_process_committee_spec.rb
+++ b/spec/system/admin/invite_process_committee_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Invite process committee", type: :system do
+  include_context "when inviting process users"
+  let(:role) { "Committee" }
+
+  before do
+    switch_to_host organization.host
+  end
+
+  context "when the user does not exist" do
+    before do
+      perform_enqueued_jobs { invite_user }
+    end
+
+    it "asks for a password and nickname and redirects to the admin dashboard" do
+      visit last_email_link
+
+      within "form.new_user" do
+        fill_in :user_nickname, with: "caballo_loco"
+        fill_in :user_password, with: "123456"
+        fill_in :user_password_confirmation, with: "123456"
+        check :user_tos_agreement
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_current_path "/admin/"
+      expect(page).to have_content("DASHBOARD")
+
+      click_link "Processes"
+
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
+      end
+    end
+  end
+
+  context "when the user already exists" do
+    let(:email) { "committee@example.org" }
+
+    let!(:committee) do
+      create :user, :confirmed, email: email, organization: organization
+    end
+
+    before do
+      perform_enqueued_jobs { invite_user }
+    end
+
+    it "redirects the committee to the admin dashboard" do
+      login_as committee, scope: :user
+
+      visit decidim_admin.root_path
+      expect(page).to have_content("DASHBOARD")
+
+      click_link "Processes"
+
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
+      end
+    end
+  end
+end

--- a/spec/system/admin/invite_process_service_spec.rb
+++ b/spec/system/admin/invite_process_service_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Invite process service", type: :system do
+  include_context "when inviting process users"
+  let(:role) { "Service" }
+
+  before do
+    switch_to_host organization.host
+  end
+
+  context "when the user does not exist" do
+    before do
+      perform_enqueued_jobs { invite_user }
+    end
+
+    it "asks for a password and nickname and redirects to the admin dashboard" do
+      visit last_email_link
+
+      within "form.new_user" do
+        fill_in :user_nickname, with: "caballo_loco"
+        fill_in :user_password, with: "123456"
+        fill_in :user_password_confirmation, with: "123456"
+        check :user_tos_agreement
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_current_path "/admin/"
+      expect(page).to have_content("DASHBOARD")
+
+      click_link "Processes"
+
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
+      end
+    end
+  end
+
+  context "when the user already exists" do
+    let(:email) { "service@example.org" }
+
+    let!(:service) do
+      create :user, :confirmed, email: email, organization: organization
+    end
+
+    before do
+      perform_enqueued_jobs { invite_user }
+    end
+
+    it "redirects the service to the admin dashboard" do
+      login_as service, scope: :user
+
+      visit decidim_admin.root_path
+      expect(page).to have_content("DASHBOARD")
+
+      click_link "Processes"
+
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR aimed to add this enhancements : 
- #3 : Add 2 Participatory Space Roles : Committee & Service

### Checklist 
- [x] Add "Committee" & "Service" to the Participatory Space Roles list
- [ ] **(To be validated)** _Add a new participatory space setting to enable to Committee/Service roles_
- [x] Add a new component setting on `Questions` to enable to Committee/Service workflow
- [x] Each new roles should be able to **only** access the `Questions` components in a participatory space
- [x] Add tests 
- [ ] Add documentation

